### PR TITLE
Entity Builder 패턴 적용 및 사용하지않는 import 제거

### DIFF
--- a/src/main/java/com/matdongsan/TestDataInit.java
+++ b/src/main/java/com/matdongsan/TestDataInit.java
@@ -20,7 +20,14 @@ public class TestDataInit {
     @PostConstruct
     public void dataInit() {
         if (memberRepository.findByUsername("member1").isEmpty()) {
-            memberRepository.save(new Member(null, "member1", passwordEncoder.encode("member1"), "member1.gmail.com", "male", LocalDateTime.now(), MemberRole.ROLE_USER));
+            memberRepository.save(Member.builder()
+                    .username("member1")
+                    .password(passwordEncoder.encode("member1"))
+                    .email("member1@gmail.com")
+                    .gender("male")
+                    .signUpDate(LocalDateTime.now())
+                    .memberRole(MemberRole.ROLE_USER)
+                    .build());
         }
     }
 }

--- a/src/main/java/com/matdongsan/domain/member/Member.java
+++ b/src/main/java/com/matdongsan/domain/member/Member.java
@@ -1,19 +1,14 @@
 package com.matdongsan.domain.member;
 
 import lombok.*;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.Collection;
 
 @Entity
-@Getter @Setter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -35,6 +30,16 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     private MemberRole memberRole;
+
+    @Builder
+    public Member(String username, String password, String email, String gender, LocalDateTime signUpDate, MemberRole memberRole) {
+        this.username = username;
+        this.password = password;
+        this.email = email;
+        this.gender = gender;
+        this.signUpDate = signUpDate;
+        this.memberRole = memberRole;
+    }
 
     public boolean matchPassword(PasswordEncoder passwordEncoder, String checkPassword) {
         return passwordEncoder.matches(checkPassword, getPassword());

--- a/src/main/java/com/matdongsan/service/MemberService.java
+++ b/src/main/java/com/matdongsan/service/MemberService.java
@@ -4,7 +4,6 @@ import com.matdongsan.domain.member.Member;
 import com.matdongsan.domain.member.MemberRepository;
 import com.matdongsan.domain.member.MemberRole;
 import com.matdongsan.infra.SecurityUser;
-import com.matdongsan.web.dto.member.MemberLoginDto;
 import com.matdongsan.web.dto.member.MemberSignUpDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
# Entity 리팩터링
## `@AllArgsConstructor` 제거
- [참고 블로그](https://velog.io/@mooh2jj/%EC%98%AC%EB%B0%94%EB%A5%B8-%EC%97%94%ED%8B%B0%ED%8B%B0-Builder-%EC%82%AC%EC%9A%A9%EB%B2%95)
> `@AllArgsConstructor`의 사용은 최대한 하지 않는 것이 좋다는 것을 듣고 제거
> 위 어노테이션은 모든 필드에 대한 생성자를 자동으로 생성해주는 역할을 하지만,
> 선언 순서에 영향을 받기 때문에 순서가 바뀌면 입력 값 순서도 바뀌게 되어
> 나중에는 찾기도 어렵고 검출되지 않는 치명적 오류를 발생시킬 수 있음
## `@Builder` 사용
> `@Setter`를 사용하게 된다면 객체를 언제 어디서든 쉽게 변경할 수 있다는 장점이자 단점이 존재
>  즉, 누가, 어디서 바꿨는지 추적하기 어려운 단점이 있으며, 불변 객체를 사용하기 위해 `@Builder`로 변경 -> 추후 `final` 추가 예정